### PR TITLE
Change highlighter

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
 title: Shoes
 safe: true
 lsi: false
-highlighter: pygments
+highlighter: rouge


### PR DESCRIPTION
Got the following warning on email after last merge for the site:

> The page build completed successfully, but returned the following warning:
> 
> You are attempting to use the 'pygments' highlighter, which is currently unsupported on GitHub Pages. Your site will use 'rouge' for highlighting instead. To suppress this warning, change the 'highlighter' value to 'rouge' in your '_config.yml' and ensure the 'pygments' key is unset. For more information, see https://help.github.com/articles/page-build-failed-config-file-error/#fixing-highlighting-errors.
> 
> For information on troubleshooting Jekyll see:
> 
>   https://help.github.com/articles/troubleshooting-jekyll-builds
> 
> If you have any questions you can contact us by replying to this email.
> 

Seem legit if we're already using that other highlighter to just have our setting to that.