### PR TITLE
add missing 4 to link to shoes4 rdocs.

### DIFF
--- a/tutorials.html
+++ b/tutorials.html
@@ -45,7 +45,8 @@ permalink: /tutorials/
     <h2><i class="fa fa-list-alt"></i> The RDocs</h2>
 
     <p>Thorough technical documentation in rdoc format.</p>
-    <a href='http://rdoc.info/github/shoes/shoes4'>Click here.</a>
+    <p> Shoes 3: <a href='http://www.rubydoc.info/github/shoes/shoes3'>Click here.</a> </p>
+    <p> Preview version of Shoes 4: <a href='http://www.rubydoc.info/github/shoes/shoes4'>Click here.</a> </p>
   </div>
 </div>
 <div class="row">

--- a/tutorials.html
+++ b/tutorials.html
@@ -45,7 +45,7 @@ permalink: /tutorials/
     <h2><i class="fa fa-list-alt"></i> The RDocs</h2>
 
     <p>Thorough technical documentation in rdoc format.</p>
-    <a href='http://rdoc.info/github/shoes/shoes'>Click here.</a>
+    <a href='http://rdoc.info/github/shoes/shoes4'>Click here.</a>
   </div>
 </div>
 <div class="row">


### PR DESCRIPTION
fix issue #86 - link was missing '4'.

unless it's supposed to reference shoes3? 

http://www.rubydoc.info/github/shoes3/shoes3
