### PR TITLE
Style GitHub with a capital H

### DIFF
--- a/contribute.html
+++ b/contribute.html
@@ -24,24 +24,24 @@ permalink: /contribute/
             <div class="col-md-4">
               <h2>Shoes 4</h2>
               <p>Shoes 4 is a complete re-write of shoes.</p>
-              <a href='https://github.com/shoes/shoes4'>Shoes 4 on Github</a>
+              <a href='https://github.com/shoes/shoes4'>Shoes 4 on GitHub</a>
             </div>
             <div class="col-md-4">
               <h2>Shoes 3.3</h2>
               <p>Shoes 3.3 is an extended version of Shoes 3</p>
-              <a href='https://github.com/Shoes3/shoes3'>Shoes 3.3 on Github</a>
+              <a href='https://github.com/Shoes3/shoes3'>Shoes 3.3 on GitHub</a>
             </div>
             <div class="col-md-4">
               <h2>Shoes</h2>
               <p>Original Shoes implementation.</p>
-              <a href='https://github.com/shoes/shoes'>Shoes on Github</a>
+              <a href='https://github.com/shoes/shoes'>Shoes on GitHub</a>
             </div>
         </div>
       <div class="row">
         <div class="col-md-4">
           <h2>shoesrb.com</h2>
           <p>Got some web skills? Help improving this website.</p>
-          <a href='https://github.com/shoes/shoesrb.com'>shoes.rb on Github</a>
+          <a href='https://github.com/shoes/shoesrb.com'>shoes.rb on GitHub</a>
         </div>
         <div class="col-md-4">
           <h2>Mailing List</h2>


### PR DESCRIPTION
GitHub styles their name with a capital "H". How about changing to match that?